### PR TITLE
update compatibility for hapi v8.x.x (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ var hapiPgOpts = {
   connectionString: 'tcp://postgres@localhost:5432/postgres'
 };
 
-server.pack.require('hapi-pg', hapiPgOpts, function(err) {
-  if(err) {
+server.register({
+  register: require('hapi-pg'),
+  options: hapiPgOpts
+}, function (err) {
+  if (err) {
     console.error(err);
     throw err;
   }
@@ -26,7 +29,16 @@ var hapiPgOpts = {
     return 'tcp://postgres@localhost:5432/' + request.query.database;
   }
 };
-server.pack.require('hapi-pg', hapiPgOpts, function(err) {});
+
+server.register({
+  register: require('hapi-pg'),
+  options: hapiPgOpts
+}, function (err) {
+  if (err) {
+    console.error(err);
+    throw err;
+  }
+});
 ```
 
 License

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ exports.register = function(plugin, options, next) {
 
   });
 
-  plugin.events.on('tail', function(request, err) {
+  plugin.on('tail', function(request, err) {
     if ( request.postgres ) {
       request.postgres.done();
     }

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "pgpass": "0.0.2"
   },
   "devDependencies": {
-    "hapi": ">5.x.x",
+    "hapi": ">=8.x.x",
     "mocha": ">1.16.2"
   },
   "peerDependencies": {
-    "hapi": ">5.x.x"
+    "hapi": ">=8.x.x"
   },
-  "readme": "hapi-pg\n=======\nWrap Hapi requests with access to a Postgres connection.\n\nIt gives you access to `request.postgres.client` within your handlers which you can then use to make Postgres requests. It also takes care of cleaning up the connection after the request.\n\nUsage\n-----\n```js\nvar hapiPgOpts = {\n  connectionString: 'tcp://postgres@localhost:5432/postgres'\n};\n\nserver.pack.require('hapi-pg', hapiPgOpts, function(err) {\n  if(err) {\n    console.error(err);\n    throw err;\n  }\n});\n```\n\nIt can also take a function to dynamically resolve connection name based on the incoming request.\n```js\nvar hapiPgOpts = {\n  connectionString: function(request) {\n    return 'tcp://postgres@localhost:5432/' + request.query.database;\n  }\n};\nserver.pack.require('hapi-pg', hapiPgOpts, function(err) {});\n```\n\nLicense\n-------\nMIT\n",
+  "readme": "hapi-pg\n=======\nWrap Hapi requests with access to a Postgres connection.\n\nIt gives you access to `request.postgres.client` within your handlers which you can then use to make Postgres requests. It also takes care of cleaning up the connection after the request.\n\nUsage\n-----\n```js\nvar hapiPgOpts = {\n  connectionString: 'tcp://postgres@localhost:5432/postgres'\n};\n\nserver.register({\n  register: require('hapi-pg'),\n  options: hapiPgOpts\n}, function (err) {\n  if (err) {\n    console.error(err);\n    throw err;\n  }\n});\n```\n\nIt can also take a function to dynamically resolve connection name based on the incoming request.\n```js\nvar hapiPgOpts = {\n  connectionString: function(request) {\n    return 'tcp://postgres@localhost:5432/' + request.query.database;\n  }\n};\n\nserver.register({\n  register: require('hapi-pg'),\n  options: hapiPgOpts\n}, function (err) {\n  if (err) {\n    console.error(err);\n    throw err;\n  }\n});\n```\n\nLicense\n-------\nMIT\n",
   "readmeFilename": "README.md",
   "homepage": "https://github.com/simplecampus/hapi-pg",
   "_id": "hapi-pg@0.0.5",


### PR DESCRIPTION
with #3, I introduced this error with `>8.x.x` (instead of `>=8.x.x`):

```
npm ERR! notarget No compatible version found: hapi@'>=9.0.0-0'
```

after changing to `>=8.x.x`:

```
hapi@8.0.0 node_modules/hapi
```

with **hapi `5.0.0`** installed, I got this error with the code on master:

```
% node index.js                                              /opt/hapi-pg-usage
/opt/hapi-pg-usage/node_modules/hapi-pg/index.js:25
  plugin.events.on('tail', function(request, err) {
                ^
TypeError: Cannot call method 'on' of undefined
```

with `hapi 8.0.0`, when I changed `plugin.events.on` to `plug.on`, the code no longer errored. this usage matches the sample usage in the ["Server events" section of the Hapi API docs](http://hapijs.com/api#server-events):

> The 'response' and 'tail' events include the request object
